### PR TITLE
feat: [PLATO-311] blog post page

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@graphql-codegen/client-preset": "1.1.4",
     "@graphql-codegen/introspection": "2.2.1",
     "@svgr/webpack": "^6.5.1",
+    "@tailwindcss/typography": "^0.5.8",
     "@types/node": "18.11.9",
     "@types/react": "18.0.25",
     "@types/react-dom": "18.0.9",

--- a/src/components/features/article/ArticleContent.tsx
+++ b/src/components/features/article/ArticleContent.tsx
@@ -1,11 +1,19 @@
+import { HTMLProps } from 'react';
+import { twMerge } from 'tailwind-merge';
+
 import { CtfRichText } from '@src/components/features/contentful';
+import { Container } from '@src/components/shared/container';
 import { PageBlogPostFieldsFragment } from '@src/lib/__generated/sdk';
 
-interface ArticleContentProps {
+interface ArticleContentProps extends HTMLProps<HTMLDivElement> {
   article: PageBlogPostFieldsFragment;
 }
-export const ArticleContent = ({ article }: ArticleContentProps) => {
+export const ArticleContent = ({ article, className, ...props }: ArticleContentProps) => {
   const { content } = article;
 
-  return <CtfRichText json={content?.json} links={content?.links} />;
+  return (
+    <Container className={twMerge('max-w-4xl', className)} {...props}>
+      <CtfRichText json={content?.json} links={content?.links} />
+    </Container>
+  );
 };

--- a/src/components/features/article/ArticleImage.tsx
+++ b/src/components/features/article/ArticleImage.tsx
@@ -1,3 +1,29 @@
-export const ArticleImage = () => {
-  return null;
+import { twMerge } from 'tailwind-merge';
+
+import { CtfImage } from '@src/components/features/contentful';
+import { ComponentRichImage } from '@src/lib/__generated/sdk';
+
+interface ArticleImageProps {
+  image: ComponentRichImage;
+}
+
+export const ArticleImage = ({ image }: ArticleImageProps) => {
+  return image.image ? (
+    <figure>
+      <div className="flex justify-center">
+        <CtfImage
+          nextImageProps={{
+            className: twMerge(
+              'mt-0 mb-0 ',
+              image.fullWidth
+                ? 'md:w-screen md:max-w-[calc(100vw-40px)] md:shrink-0'
+                : 'rounded-2xl border border-gray300 shadow-lg',
+            ),
+          }}
+          {...image.image}
+        />
+      </div>
+      {image.caption && <figcaption className="mt-4">{image.caption}</figcaption>}
+    </figure>
+  ) : null;
 };

--- a/src/components/features/contentful/CtfImage.tsx
+++ b/src/components/features/contentful/CtfImage.tsx
@@ -2,7 +2,7 @@ import NextImage, { ImageProps as NextImageProps } from 'next/image';
 
 import { ImageFieldsFragment } from '@src/lib/__generated/sdk';
 
-interface ImageProps extends ImageFieldsFragment {
+interface ImageProps extends Omit<ImageFieldsFragment, '__typename'> {
   nextImageProps?: Omit<NextImageProps, 'src' | 'alt'>;
 }
 

--- a/src/components/features/contentful/CtfRichText.tsx
+++ b/src/components/features/contentful/CtfRichText.tsx
@@ -1,9 +1,10 @@
 import { documentToReactComponents, Options } from '@contentful/rich-text-react-renderer';
 import { BLOCKS, Document } from '@contentful/rich-text-types';
 
-import { ImageFieldsFragment } from '@src/lib/__generated/sdk';
+import { ArticleImage } from '@src/components/features/article';
+import { ComponentRichImage } from '@src/lib/__generated/sdk';
 
-export type EmbeddedEntryType = ImageFieldsFragment | null;
+export type EmbeddedEntryType = ComponentRichImage | null;
 
 export interface ContentfulRichTextInterface {
   json: Document;
@@ -16,6 +17,15 @@ export interface ContentfulRichTextInterface {
     | any;
 }
 
+export const EmbeddedEntry = (entry: EmbeddedEntryType) => {
+  switch (entry?.__typename) {
+    case 'ComponentRichImage':
+      return <ArticleImage image={entry} />;
+    default:
+      return null;
+  }
+};
+
 export const contentfulBaseRichTextOptions = ({ links }: ContentfulRichTextInterface): Options => ({
   renderNode: {
     [BLOCKS.EMBEDDED_ENTRY]: node => {
@@ -25,7 +35,7 @@ export const contentfulBaseRichTextOptions = ({ links }: ContentfulRichTextInter
 
       if (!entry) return null;
 
-      return <>--PLACEHOLDER-- Embedded entry --PLACEHOLDER--</>;
+      return <EmbeddedEntry {...entry} />;
     },
   },
 });
@@ -33,5 +43,9 @@ export const contentfulBaseRichTextOptions = ({ links }: ContentfulRichTextInter
 export const CtfRichText = ({ json, links }: ContentfulRichTextInterface) => {
   const baseOptions = contentfulBaseRichTextOptions({ links, json });
 
-  return <div>{documentToReactComponents(json, baseOptions)}</div>;
+  return (
+    <article className="prose prose-sm max-w-none">
+      {documentToReactComponents(json, baseOptions)}
+    </article>
+  );
 };

--- a/src/lib/__generated/sdk.ts
+++ b/src/lib/__generated/sdk.ts
@@ -1468,7 +1468,7 @@ export type PageLandingCollectionQuery = { __typename?: 'Query', pageLandingColl
       & PageLandingFieldsFragment
     ) | null> } | null };
 
-export type RichImageFieldsFragment = { __typename: 'ComponentRichImage', caption?: string | null, fullWidth?: boolean | null, image?: (
+export type RichImageFieldsFragment = { __typename: 'ComponentRichImage', caption?: string | null, fullWidth?: boolean | null, sys: { __typename?: 'Sys', id: string }, image?: (
     { __typename?: 'Asset' }
     & ImageFieldsFragment
   ) | null };
@@ -1531,6 +1531,9 @@ export const AuthorFieldsFragmentDoc = gql`
 export const RichImageFieldsFragmentDoc = gql`
     fragment RichImageFields on ComponentRichImage {
   __typename
+  sys {
+    id
+  }
   image {
     ...ImageFields
   }

--- a/src/lib/graphql/richImageFields.graphql
+++ b/src/lib/graphql/richImageFields.graphql
@@ -1,5 +1,8 @@
 fragment RichImageFields on ComponentRichImage {
   __typename
+  sys {
+    id
+  }
   image {
     ...ImageFields
   }

--- a/src/pages/[slug].page.tsx
+++ b/src/pages/[slug].page.tsx
@@ -16,9 +16,9 @@ const Page = ({ blogPost, isFeatured }: InferGetStaticPropsType<typeof getStatic
     <>
       {blogPost.seoFields && <SeoFields {...blogPost.seoFields} />}
       <ArticleHero article={blogPost} isFeatured={isFeatured} isReversedLayout={true} />
-      <ArticleContent article={blogPost} />
+      <ArticleContent className="mt-8" article={blogPost} />
       {blogPost.relatedBlogPostsCollection?.items && (
-        <Container className="max-w-5xl">
+        <Container className="mt-8 max-w-5xl">
           <h2 className="mb-4 md:mb-6">{t('article.relatedArticles')}</h2>
           <ArticleTileGrid className="md:grid-cols-2" article={blogPost} />
         </Container>

--- a/src/pages/utils/globals.css
+++ b/src/pages/utils/globals.css
@@ -28,7 +28,7 @@
   }
 
   p {
-    @apply text-gray600 tracking-snug font-normal leading-4 md:leading-5;
+    @apply text-gray600 tracking-snug font-normal leading-snug md:leading-normal;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -35,4 +35,5 @@ module.exports = {
       },
     },
   },
+  plugins: [require('@tailwindcss/typography')],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2140,6 +2140,16 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tailwindcss/typography@^0.5.8":
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.8.tgz#8fb31db5ab0590be6dfa062b1535ac86ad9d12bf"
+  integrity sha512-xGQEp8KXN8Sd8m6R4xYmwxghmswrd0cPnNI2Lc6fmrC3OojysTBJJGSIVwPV56q4t6THFUK3HJ0EaWwpglSxWw==
+  dependencies:
+    lodash.castarray "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+    postcss-selector-parser "6.0.10"
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
@@ -5020,6 +5030,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+  integrity sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -5739,6 +5754,14 @@ postcss-nested@6.0.0:
   integrity sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==
   dependencies:
     postcss-selector-parser "^6.0.10"
+
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
 postcss-selector-parser@^6.0.10:
   version "6.0.11"


### PR DESCRIPTION
**_What will change?_**

- Added Tailwind Prose to the Rich text component
- Added the `ArticleImage` component
- The `CtfRichText` component now can render Embedded Block Entries, currently only supporting an `ArticleImage`
- Tweaked the line-height paragraph tags

https://contentful.atlassian.net/browse/PLATO-311

**Testing instructions**
- Visit `/test-article-two`