### PR TITLE
fix: [PLATO-0000] Fix ISR

### DIFF
--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -80,8 +80,8 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
     }
 
     return {
+      revalidate: revalidateDuration,
       props: {
-        revalidate: revalidateDuration,
         ...(await getServerSideTranslations(locale)),
         page,
         posts,


### PR DESCRIPTION
`revalidate` was at the wrong level (should be a sibling to `props`). Therefore when content was updated, ISR didn't kick in and update with the correct data.