### PR TITLE
chore: [] Sentry tweaks

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -91,6 +91,7 @@ const sentryWebpackPluginOptions = {
   //   release, url, org, project, authToken, configFile, stripPrefix,
   //   urlPrefix, include, ignore
 
+  ignore: [],
   silent: true, // Suppresses all logs
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options.


### PR DESCRIPTION
**_What will change?_**

- Found an old thread that described our issues (clientside first load JS not being included) Cleared the ignore list for the sentryWebpackPluginOptions, https://github.com/getsentry/sentry-javascript/issues/5328#issuecomment-1222399239

Supposedly this will include sourcemaps from node_modules. We'll have to see what this does in terms of artifacts.

We went from 50 to 134 when widerning the scope in a previous PR. Will monitor what this does
