### PR TITLE
fix: Prioritise Vercel/Netlify env settings over the default URLs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  command = "NEXT_PUBLIC_BASE_URL=$URL yarn build"
+  command = "NEXT_PUBLIC_BASE_URL=\"${URL:-$URL}\" yarn build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  command = "NEXT_PUBLIC_BASE_URL=\"${URL:-$URL}\" yarn build"
+  command = "NEXT_PUBLIC_BASE_URL=\"${NEXT_PUBLIC_BASE_URL:-$URL}\" yarn build"

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "buildCommand": "NEXT_PUBLIC_BASE_URL=\"https://$NEXT_PUBLIC_VERCEL_URL\" yarn build"
+  "buildCommand": "NEXT_PUBLIC_BASE_URL=\"${NEXT_PUBLIC_BASE_URL:-https://$NEXT_PUBLIC_VERCEL_URL}\" yarn build"
 }


### PR DESCRIPTION
**_What will change?_**

Tweaked the configuration files so that if the `NEXT_PUBLIC_BASE_URL` is already set then it is used in place of the hosting provider URL.

