### PR TITLE
feat: [PLATO-520] cherry-pick commit from main and reslove conflict

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Check if .env file already exists
+if [ -f .env ]; then
+  echo ".env.example file does not exist. Aborting."
+  exit 1
+fi
+
+# Check if .env.example file exists
+if [ ! -f .env.example ]; then
+  echo ".env.example file does not exist. Aborting."
+  exit 1
+fi
+
+# Copy .env.example to .env
+cp .env.example .env
+
+# Read the values of the variables from command-line arguments
+for arg in "$@"; do
+  if [[ "$arg" != *"="* ]]; then
+    echo "Invalid argument: $arg. Arguments must be in the format KEY=VALUE. Aborting."
+    exit 1
+  fi
+
+  key=$(echo "$arg" | cut -d'=' -f1)
+  value=$(echo "$arg" | cut -d'=' -f2)
+
+  # Sanitize inputs
+  if [[ "$key" != *[![:alnum:]_]* ]]; then
+    sed -e "s/^${key}=.*/${key}=${value}/" .env > temp && mv temp .env
+  else
+    echo "Invalid key: $key. Keys must contain only letters, numbers, and underscores. Aborting."
+    exit 1
+  fi
+done
+
+# install node_modules and run dev
+echo Installing dependencies
+yarn
+yarn dev

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "graphql-codegen:generate": "graphql-codegen -r dotenv/config --config codegen.ts",
     "graphql-codegen:watch": "graphql-codegen --watch -r dotenv/config --config codegen.ts",
     "typewriter:init": "node ./analytics/generateTypewriterConfig.js",
-    "typewriter:update": "yarn typewriter --update"
+    "typewriter:update": "yarn typewriter --update",
+    "setup": "./bin/setup.sh"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
## Purpose of PR

In order to speed up local setup for users, we added the setup script so that when the user run this script in their CLI:
`yarn setup CONTENTFUL_SPACE_ID=usersSpaceId CONTENTFUL_DELIVERY_API_TOKEN=usersDeliveryToken CONTENTFUL_PREVIEW_API_TOKEN=usersPreviewToken`

this will:
- create .env file 
- pre-fills all the necessary envs
- copy all contents from .env.example to .env
- find CONTENTFUL_SPACE_ID,CONTENTFUL_DELIVERY_API_TOKEN and CONTENTFUL_PREVIEW_API_TOKEN and fill the values from npm arguments.
- Install dependencies
- run the app

[Ticket](https://contentful.atlassian.net/browse/PLATO-520)

To test:
- delete .env and node_modules
- run the script:
`yarn setup CONTENTFUL_SPACE_ID=usersSpaceId CONTENTFUL_DELIVERY_API_TOKEN=usersDeliveryToken CONTENTFUL_PREVIEW_API_TOKEN=usersPreviewToken`