### PR TITLE
[SEC-2948]: Add SAST scans for Security

### DIFF
--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -1,0 +1,31 @@
+name: SAST (Static Application Security Testing)
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  polaris:
+    name: polaris / code-scan
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    if: (github.repository_owner == 'contentful') && (endsWith(github.actor, '[bot]') == false)
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Synopsys Polaris
+        uses: contentful/polaris-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          polaris_url: ${{ secrets.POLARIS_SERVER_URL }}
+          polaris_access_token: ${{ secrets.POLARIS_ACCESS_TOKEN }}
+          debug: true
+          polaris_command: analyze -w --coverity-ignore-capture-failure
+          security_gate_filters: '{ "severity": ["High", "Medium"] }'
+          fail_on_error: false
+          report_url: "https://github.com/contentful/security-tools-config/issues/new?title=False%20positive%20in%20Polaris"

--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master, main, main-private]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, main-private]
 
 jobs:
   polaris:

--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -2,7 +2,7 @@ name: SAST (Static Application Security Testing)
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, main-private]
   pull_request:
     branches: [master, main]
 


### PR DESCRIPTION
Adds Polaris SAST scaning GHA. https://contentful.atlassian.net/browse/SEC-2948

**_What will change?_**

- Stuff that is going to change
- even more interesting stuff that is going to change

<!-- If this has a larger context, uncomment and put it here
_Purpose_

Why do we introduce this change? What problem do we solve? What is the
story/background for it?
-->

<!-- # Uncomment if you have any dependencies
**_Dependencies and/or References_**

* Another related PR
* A Confluence page
* External documentation

-->

<!-- # If there is some insights/learnings to share, put them here
**_Learnings_**

-->

<!-- # If there is deployment related information, uncomment and put it here
**_Deployment & Risks_**

* [x] All tests and checks are passing (or any failures are well understood and acceptable)
* [x] This PR is ready to be deployed to production (once successfully merged with the `main` branch)
* [ ] There is a migration necessary for this to work
* [ ] There is a dependent PR that needs to be deployed first
-->

## Security

_Before you click Merge, take a step back and think how someone could break the [Confidentiality, Integrity and Availability](https://docs.google.com/presentation/d/1YdFlYBLnbNoiSAMOKjopiF4u34StXTK2qYdOLkMsEKo/edit?usp=sharing) of the code you've just written. Are secrets secret? Is there any sensitive information disclosed in logs or error messages? How does your code ensure that information is accurate, complete and protected from modification? Will your code keep Contentful working and functioning?_

<!-- # Reminders
* [Write good pull requests!](https://seesparkbox.com/foundry/github_pull_requests_for_everyone) 👼
* [Be a good reviewer!](https://seesparkbox.com/foundry/stop_giving_depressing_code_reviews) 🧐
-->
