### PR TITLE
feat: [] Next.js preview mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ CONTENTFUL_ACCESS_TOKEN=
 
 # Your current space Content Preview API access token: https://www.contentful.com/developers/docs/references/content-preview-api/
 CONTENTFUL_PREVIEW_ACCESS_TOKEN=
+
+# A unique string used to identify preview requests: https://nextjs.org/docs/advanced-features/preview-mode#securely-accessing-it-from-your-headless-cms
+CONTENTFUL_PREVIEW_SECRET=

--- a/README.md
+++ b/README.md
@@ -194,11 +194,25 @@ environment variables.
 
 ---
 
-### Content preview
+## Content preview
 
-Once you have the Starter Template deployed on your hosting provider, you can update the Content preview URL in your space settings.
+Our Starter Templates are configured to make use of Next.js' [preview mode](https://nextjs.org/docs/advanced-features/preview-mode). To make use of Contentful's Content Preview we requires a few changes to be made in the code, and in Contentful.  
 
-You can follow our guide to learn how to do so: [https://www.contentful.com/help/setup-content-preview](https://www.contentful.com/help/setup-content-preview/?utm_source=github.com-guide&utm_medium=referral&utm_campaign=template-blog-webapp-nextjs).
+### Adjustments in code
+
+1. Set a unique value for `process.env.CONTENTFUL_PREVIEW_SECRET` in your environment variables. This value should be kept secret and only known to the API route and the CMS.
+2. Configure the entry preview URLs in Contentful to match the preview API route's URL structure. This can be done in the Contentful web interface under "Settings" for each content type. For more information see: https://www.contentful.com/help/setup-content-preview/#preview-content-in-your-online-environment 
+3. The preview API route is already written in the app and can be found in `pages/api/preview.js`. This route checks for a valid secret and slug before redirecting to the corresponding page*. 
+4. To exit preview mode, use the `clearPreviewData` method and redirect the user back to the index page. This route is already written in the app and can be found in `pages/api/exit-preview.js`.
+
+_*The `slug` field is optional; When not passed we redirect the page to the root of the domain._
+
+### Adjustments in Contentful
+
+1. Next, you will need to configure your Contentful space to use the correct preview URLs. To do this, go to the "Settings" section of your space, and click on the "Content Preview" tab. From here, you can configure the preview URLs for each of your content models. 
+2. Edit all content models that need a preview url. We usually expect that to only be the models prefixed with `📄 page -`.
+3. Add a new URL with the following format: `https://<your-site>/api/preview?secret=<token>&slug={entry.fields.slug}`. Make sure to replace `<your-site>` with the URL of your Next.js site, and `<token>` with the value of `process.env.CONTENTFUL_PREVIEW_SECRET`.
+4. Now, when you view an unpublished entry in Contentful, you should see a "Preview" button that will take you to the preview URL for that entry. Clicking this button should show you a preview of the entry on your Next.js site, using the preview API route that we set up earlier.
 
 $~$
 

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -9,4 +9,11 @@ const graphQlClient = new GraphQLClient(endpoint, {
   },
 });
 
+const previewGraphQlClient = new GraphQLClient(endpoint, {
+  headers: {
+    Authorization: `Bearer ${process.env.CONTENTFUL_PREVIEW_ACCESS_TOKEN}`,
+  },
+});
+
 export const client = getSdk(graphQlClient);
+export const previewClient = getSdk(previewGraphQlClient);

--- a/src/pages/api/exit-preview.page.tsx
+++ b/src/pages/api/exit-preview.page.tsx
@@ -1,0 +1,8 @@
+export default async function exit(_, res) {
+  // Exit the current user from "Preview Mode". This function accepts no args.
+  res.clearPreviewData();
+
+  // Redirect the user back to the index page.
+  res.writeHead(307, { Location: '/' });
+  res.end();
+}

--- a/src/pages/api/preview.page.tsx
+++ b/src/pages/api/preview.page.tsx
@@ -1,0 +1,47 @@
+import { previewClient } from '@src/lib/client';
+
+export default async (req, res) => {
+  const { secret, slug, locale } = req.query;
+
+  // Check the secret and next parameters
+  // This secret should only be known to this API route and the CMS
+  if (secret !== process.env.CONTENTFUL_PREVIEW_SECRET) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+
+  // Check for a slug, if no slug is passed we assume we need to redirect to the root
+  if (slug) {
+    try {
+      const blogPageData = await previewClient.pageBlogPost({
+        slug,
+        locale,
+        preview: true,
+      });
+
+      const blogPost = blogPageData.pageBlogPostCollection?.items[0];
+
+      if (!blogPost) {
+        throw Error();
+      }
+
+      res.redirect(`/${blogPost?.slug}`);
+    } catch {
+      return res.status(401).json({ message: 'Invalid slug' });
+    }
+  } else {
+    try {
+      const landingPageData = await previewClient.pageLanding({
+        locale,
+        preview: true,
+      });
+
+      if (!landingPageData) {
+        throw Error();
+      }
+
+      res.redirect('/');
+    } catch {
+      return res.status(401).json({ message: 'Page not found' });
+    }
+  }
+};

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -8,7 +8,7 @@ import { ArticleHero, ArticleTileGrid } from '@src/components/features/article';
 import { SeoFields } from '@src/components/features/seo';
 import { Container } from '@src/components/shared/container';
 import { PageBlogPostOrder } from '@src/lib/__generated/sdk';
-import { client } from '@src/lib/client';
+import { client, previewClient } from '@src/lib/client';
 import { revalidateDuration } from '@src/pages/utils/constants';
 
 const Page = ({ page, posts }: InferGetStaticPropsType<typeof getStaticProps>) => {
@@ -39,18 +39,21 @@ const Page = ({ page, posts }: InferGetStaticPropsType<typeof getStaticProps>) =
   );
 };
 
-export const getStaticProps: GetStaticProps = async ({ locale }) => {
+export const getStaticProps: GetStaticProps = async ({ locale, preview }) => {
   try {
-    const landingPageData = await client.pageLanding({ locale });
+    const gqlClient = preview ? previewClient : client;
+
+    const landingPageData = await gqlClient.pageLanding({ locale, preview });
     const page = landingPageData.pageLandingCollection?.items[0];
 
-    const blogPostsData = await client.pageBlogPostCollection({
+    const blogPostsData = await gqlClient.pageBlogPostCollection({
       limit: 6,
       locale,
       order: PageBlogPostOrder.PublishedDateDesc,
       where: {
         slug_not: page?.featuredBlogPost?.slug,
       },
+      preview,
     });
     const posts = blogPostsData.pageBlogPostCollection?.items;
 


### PR DESCRIPTION
**_What will change?_**

Added support for Next.js their preview mode. https://nextjs.org/docs/advanced-features/preview-mode. API routes have been added to handle previews URLs, and to reset the preview mode.

A `previewGraphQlClient` was added which is used in favor of the `graphQlClient` when the preview mode is active. The `index` and `slug` page have been modified accordingly to account for this.

Several typos have been fixed as well.

