### PR TITLE
chore: [PLATO-718] update the CSP header domains

### DIFF
--- a/config/headers.js
+++ b/config/headers.js
@@ -13,7 +13,7 @@ const securityHeaders = [
   },
   {
     key: 'Content-Security-Policy',
-    value: `frame-ancestors 'self' https://app.contentful.com`,
+    value: `frame-ancestors 'self' https://app.contentful.com https://app.flinkly.com https://app.quirely.com http://localhost:3001`,
   },
   {
     key: 'X-Content-Type-Options',


### PR DESCRIPTION
**_What will change?_**

We introduce headers to be able to work with the Contentful Live Preview on non-production environments.

Ticket: https://contentful.atlassian.net/browse/PLATO-718

--- 

**Before introducing the domains**

<img width="1499" alt="localhost-before" src="https://github.com/contentful/template-blog-webapp-nextjs/assets/103024358/60169488-28df-4558-b587-fda4bf8715d4">

**After introducing the domains**

<img width="1497" alt="localhost-after" src="https://github.com/contentful/template-blog-webapp-nextjs/assets/103024358/0674cd2e-eb2a-4c6b-83f0-e80b2060272a">
