### PR TITLE
fix: [PLATO-842] Add eu domain to images optimization and CSP

### DIFF
--- a/config/headers.js
+++ b/config/headers.js
@@ -13,7 +13,7 @@ const securityHeaders = [
   },
   {
     key: 'Content-Security-Policy',
-    value: `frame-ancestors 'self' https://app.contentful.com`,
+    value: `frame-ancestors 'self' https://app.contentful.com https://app.eu.contentful.com`,
   },
   {
     key: 'X-Content-Type-Options',

--- a/next.config.js
+++ b/next.config.js
@@ -57,7 +57,7 @@ module.exports = withPlugins(plugins, {
    * Settings are the defaults
    */
   images: {
-    domains: ['images.ctfassets.net'],
+    domains: ['images.ctfassets.net','images.eu.ctfassets.net'],
   },
 
   pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],


### PR DESCRIPTION
What will change?

added 'app.eu.contentful.com' to Content-Security-Policy so that it would allow the site to be embedded in an iframe from the eu-contentful.
added 'images.eu.ctfassets.net' to images - domains
ticket: https://contentful.atlassian.net/browse/PLATO-842