### PR TITLE
chore: [] remove unused npm-read policy

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -3,4 +3,3 @@ services:
   github-action:
     policies:
     - dependabot
-    - npm-read


### PR DESCRIPTION
Removed `npm-read` policy that not in use for GitHub actions
