### PR TITLE
chore(ci): add vault policy for gh packages []

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -3,3 +3,4 @@ services:
   github-action:
     policies:
     - dependabot
+    - packages-read


### PR DESCRIPTION
**_What will change?_**

- the NPM policy was removed once in the past from main, as it seemed that it's not used (only on main-private and further private branches).
- adding the policy for packages-read now