### PR TITLE
fix: add allowed origin domains for staging/preview live preview

### DIFF
--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -9,6 +9,16 @@ import { CtfSegmentAnalytics } from '@src/_ctf-private/ctf-analytics';
 import { Layout } from '@src/components/templates/layout';
 import './utils/globals.css';
 
+const allowedOriginList = [
+  'https://app.contentful.com',
+  'https://app.eu.contentful.com',
+  'https://app.flinkly.com',
+  'https://app.eu.flinkly.com',
+  'https://app.quirely.com',
+  'https://app.eu.quirely.com',
+  'http://localhost:3001',
+];
+
 const urbanist = Urbanist({ subsets: ['latin'], variable: '--font-urbanist' });
 
 const App = ({ Component, pageProps }: AppProps) => {
@@ -21,7 +31,8 @@ const App = ({ Component, pageProps }: AppProps) => {
     <ContentfulLivePreviewProvider
       enableInspectorMode={true}
       enableLiveUpdates={true}
-      locale={locale || 'en-US'}>
+      locale={locale || 'en-US'}
+      targetOrigin={allowedOriginList}>
       <CtfCustomQueryClientProvider>
         <CtfSegmentAnalytics />
         <main className={`${urbanist.variable} font-sans`}>


### PR DESCRIPTION
**_What will change?_**

Adds allowed origin domains for Live Preview on staging/preview environments.

![live-preview](https://github.com/contentful/template-ecommerce-webapp-nextjs/assets/103024358/129f8d9f-49e8-45d4-91f2-2b8c4068ca50)

![live-preview-origin](https://github.com/contentful/template-ecommerce-webapp-nextjs/assets/103024358/096a8bac-9ecc-41ab-8fd3-ec2e7f09f885)

