### PR TITLE
feat: add metadata to all pages

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,14 +10,13 @@ import { Header } from '@src/components/templates/header';
 import initTranslations from '@src/i18n';
 import { locales } from '@src/i18n/config';
 
-export async function generateMetadata() {
-  const metatadata: Metadata = {
+export async function generateMetadata(): Promise<Metadata> {
+  return {
     metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL!),
-    title: 'Contenful - Best CMS',
-    description: 'Content that takes you from anywhere to everywhere',
-  } as Metadata;
-
-  return metatadata;
+    twitter: {
+      card: 'summary_large_image',
+    },
+  };
 }
 
 export const viewport: Viewport = {

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -13,6 +13,8 @@ import { locales } from '@src/i18n/config';
 export async function generateMetadata() {
   const metatadata: Metadata = {
     metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL!),
+    title: 'Contenful - Best CMS',
+    description: 'Content that takes you from anywhere to everywhere',
   } as Metadata;
 
   return metatadata;

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,7 +10,7 @@ import { Header } from '@src/components/templates/header';
 import initTranslations from '@src/i18n';
 import { locales } from '@src/i18n/config';
 
-export async function generateMetadata(): Promise<Metadata> {
+export function generateMetadata(): Metadata {
   return {
     metadataBase: new URL(process.env.NEXT_PUBLIC_BASE_URL!),
     twitter: {

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -13,6 +13,7 @@ export default async function NotFound() {
 
   return (
     <Container>
+      <title>{t('notFound.title')}</title>
       <h1 className="h2">{t('notFound.title')}</h1>
       <p className="mt-4">
         <Trans i18nKey="notFound.description" t={t}>

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -7,7 +7,7 @@ import { ArticleHero, ArticleTileGrid } from '@src/components/features/article';
 import { Container } from '@src/components/shared/container';
 import TranslationsProvider from '@src/components/shared/i18n/TranslationProvider';
 import initTranslations from '@src/i18n';
-import { locales } from '@src/i18n/config';
+import { defaultLocale, locales } from '@src/i18n/config';
 import { PageBlogPostOrder } from '@src/lib/__generated/sdk';
 import { client, previewClient } from '@src/lib/client';
 
@@ -22,32 +22,22 @@ export async function generateMetadata({ params }: LandingPageProps): Promise<Me
   const gqlClient = preview ? previewClient : client;
   const landingPageData = await gqlClient.pageLanding({ locale: params.locale, preview });
   const page = landingPageData.pageLandingCollection?.items[0];
-  const languages = locales.length > 1 ? {} : undefined;
 
-  if (languages) {
-    for (const locale of locales) {
-      languages[locale] = `/${locale}`;
-    }
-  }
-
-  let metadata: Metadata = {
+  const languages = Object.fromEntries(
+    locales.map(locale => [locale, locale === defaultLocale ? '/' : `/${locale}`]),
+  );
+  const metadata: Metadata = {
     alternates: {
       canonical: '/',
-      languages,
-    },
-    twitter: {
-      card: 'summary_large_image',
+      languages: languages,
     },
   };
-
   if (page?.seoFields) {
-    metadata = {
-      title: page.seoFields.pageTitle,
-      description: page.seoFields.pageDescription,
-      robots: {
-        follow: !page.seoFields.nofollow,
-        index: !page.seoFields.noindex,
-      },
+    metadata.title = page.seoFields.pageTitle;
+    metadata.description = page.seoFields.pageDescription;
+    metadata.robots = {
+      follow: !page.seoFields.nofollow,
+      index: !page.seoFields.noindex,
     };
   }
 


### PR DESCRIPTION
This PR adds missing metadata for all routes.

- `generateMetadata` in `layout.tsx` acts as a base metadata that is extended/overridden within the different pages
- There was a bug where `alternate` was overridden.
- blog posts didn't have a title/description
- You can't use `generateMetadata` for the not found route. `<title>` is used instead